### PR TITLE
Add test_args input to the CI reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: false
         type: boolean
+      test_args:
+        description: "Arguments string forwarded to julia-runtest's test_args (e.g. 'GPU' to select a package's GPU-specific test suite). Empty by default (no arguments)."
+        required: false
+        type: string
+        default: ''
     secrets:
       SSH_KEY:
         required: false
@@ -104,3 +109,5 @@ jobs:
 
       - name: Run tests
         uses: julia-actions/julia-runtest@latest
+        with:
+          test_args: ${{ inputs.test_args }}


### PR DESCRIPTION
## Summary

- Adds a `test_args` input (string, default `''`) to `ci.yml`, forwarded to `julia-actions/julia-runtest`'s own `test_args` input.
- Backward-compatible: every existing caller keeps its current behavior (empty `test_args` is a no-op for `julia-runtest`).

## Motivation

CTDirect.jl carries a separate hand-rolled `GPU.yml` workflow whose only reason to exist is passing `test_args: 'GPU'` to select its GPU-specific test suite (`test/test_gpu.jl`, gated in `test/runtests.jl` via `"GPU" in ARGS`). With this input, that need is met by the shared `ci.yml` directly — CTDirect folds it into its `CI.yml`'s `test-gpu-kkt` job and drops `GPU.yml` entirely. Companion PR: control-toolbox/CTDirect.jl (branch `shape/probe-scalar-audit-613`).

## Test plan

- [ ] Confirm no existing caller passes `test_args` today (grep across the org's `.github/workflows/CI.yml` callers) — none do, so this is additive only.
- [ ] CTDirect's `test-gpu-kkt` job (using this branch pinned temporarily, then `@main` after merge) runs `test/test_gpu.jl` on the `kkt` runner.